### PR TITLE
Update Go, remove unused test buildtags +  run goimports & gofmt

### DIFF
--- a/composition.go
+++ b/composition.go
@@ -163,7 +163,7 @@ func (comp Composition) Deps(s string) (services []string) {
 	return services
 }
 
-//error if removed service is a dependencies of another service which should not be removed
+// error if removed service is a dependencies of another service which should not be removed
 func removeNotWanted(comp Composition, s string) (todo map[string]bool, err error) {
 	todo = make(map[string]bool)
 	var notwanted []string

--- a/composition_test.go
+++ b/composition_test.go
@@ -1,3 +1,4 @@
+//go:build !integrationtest || unittest
 // +build !integrationtest unittest
 
 package main
@@ -38,7 +39,7 @@ func TestVerifyDependencies(t *testing.T) {
 	}
 }
 
-////
+// //
 func TestOutputDotGraph(t *testing.T) {
 	comp := makeTestComp()
 	dot, _ := outputDotGraph(*comp)

--- a/composition_test.go
+++ b/composition_test.go
@@ -1,6 +1,3 @@
-//go:build !integrationtest || unittest
-// +build !integrationtest unittest
-
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/simplesurance/dependencies-tool
 
-go 1.15
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,4 @@
+//go:build !integrationtest || unittest
 // +build !integrationtest unittest
 
 package main

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,3 @@
-//go:build !integrationtest || unittest
-// +build !integrationtest unittest
-
 package main
 
 import (

--- a/sisu_test.go
+++ b/sisu_test.go
@@ -1,3 +1,4 @@
+//go:build !integrationtest || unittest
 // +build !integrationtest unittest
 
 package main

--- a/sisu_test.go
+++ b/sisu_test.go
@@ -1,6 +1,3 @@
-//go:build !integrationtest || unittest
-// +build !integrationtest unittest
-
 package main
 
 import (


### PR DESCRIPTION
```
remove unused build tags in test files

remove the integrationtest and unittest build tags, they are not needed,
all tests are unit tests and can be run in the "go test" invocation.

-------------------------------------------------------------------------------
fix minor formatting issues

run 'goimports -w' and 'gofmt -s -w'

-------------------------------------------------------------------------------
go: set min. version to 1.21
```