### PR TITLE
replace DepService with an empty struct

### DIFF
--- a/composition.go
+++ b/composition.go
@@ -10,23 +10,13 @@ import (
 	"github.com/thcyron/graphs"
 )
 
-// DepService ...
-type DepService struct {
-	Condition string `json:"condition"`
-}
-
-// NewDepService creates new DepService
-func NewDepService() DepService {
-	return DepService{}
-}
-
 // Service ...
 type Service struct {
-	DependsOn map[string]DepService `json:"depends_on"`
+	DependsOn map[string]struct{} `json:"depends_on"`
 }
 
 // AddDependency adds a service
-func (s *Service) AddDependency(name string, service DepService) {
+func (s *Service) AddDependency(name string, service struct{}) {
 	if _, ok := s.DependsOn[name]; !ok {
 		s.DependsOn[name] = service
 	}
@@ -34,7 +24,7 @@ func (s *Service) AddDependency(name string, service DepService) {
 
 // NewService creates a new Service
 func NewService() Service {
-	deps := make(map[string]DepService)
+	deps := make(map[string]struct{})
 	return Service{DependsOn: deps}
 }
 

--- a/composition_test.go
+++ b/composition_test.go
@@ -12,8 +12,8 @@ func makeTestComp() (comp *Composition) {
 	bService := NewService()
 	cService := NewService()
 
-	aService.AddDependency("c", NewDepService())
-	bService.AddDependency("a", NewDepService())
+	aService.AddDependency("c", struct{}{})
+	bService.AddDependency("a", struct{}{})
 
 	comp = NewComposition()
 	comp.AddService("b", bService)
@@ -26,7 +26,7 @@ func makeTestComp() (comp *Composition) {
 func TestVerifyDependencies(t *testing.T) {
 	comp := makeTestComp()
 	dService := NewService()
-	dService.AddDependency("notDefined", NewDepService())
+	dService.AddDependency("notDefined", struct{}{})
 	comp.AddService("d", dService)
 
 	if err := comp.VerifyDependencies(""); err == nil {
@@ -57,7 +57,7 @@ func TestOutputDotGraph(t *testing.T) {
 
 func TestPrepareForOwnDb(t *testing.T) {
 	a := NewService()
-	a.AddDependency("postgres", NewDepService())
+	a.AddDependency("postgres", struct{}{})
 	comp := NewComposition()
 	comp.AddService("a", a)
 	comp.PrepareForOwnDb()
@@ -69,7 +69,7 @@ func TestPrepareForOwnDb(t *testing.T) {
 
 func TestAddDependency(t *testing.T) {
 	service := NewService()
-	dep := NewDepService()
+	dep := struct{}{}
 
 	service.AddDependency("dep1", dep)
 

--- a/sisu.go
+++ b/sisu.go
@@ -144,7 +144,7 @@ func compositionFromSisuDir(directory string) (comp Composition, err error) {
 		service := NewService()
 		if len(t.TalksTo) > 0 {
 			for _, depservice := range t.TalksTo {
-				service.AddDependency(depservice, NewDepService())
+				service.AddDependency(depservice, struct{}{})
 			}
 		}
 		comp.AddService(t.Name, service)
@@ -195,7 +195,7 @@ func compositionFromAppdirFile(file string) (comp Composition, err error) {
 		service := NewService()
 		if len(t.TalksTo) > 0 {
 			for _, depservice := range t.TalksTo {
-				service.AddDependency(depservice, NewDepService())
+				service.AddDependency(depservice, struct{}{})
 			}
 		}
 		comp.AddService(t.Name, service)


### PR DESCRIPTION
The DepService struct is used as value for the DepensOn map but it's only field "Condition" was not used.
Replace the DepService struct with an empty struct. This is more clear, easier to maintain and requires less memory during execution.