### PR TITLE
ci: add custom golangci-lint config + fix warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+---
+linters:
+  disable-all: false
+  enable:
+    - bodyclose
+    - errcheck
+    - errorlint
+    - exportloopref
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nolintlint
+    - prealloc
+    - revive
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - usestdlibvars
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/simplesurance/dependencies-tool
+
+issues:
+  exclude-use-default: true

--- a/composition.go
+++ b/composition.go
@@ -265,17 +265,17 @@ func outputDotGraph(comp Composition) (s string, err error) {
 	graph.Directed = true
 
 	if err := graph.AddAttr("G", "splines", "\"ortho\""); err != nil {
-		return s, fmt.Errorf("could not add Attribute splines: %v", err)
+		return s, fmt.Errorf("could not add Attribute splines: %w", err)
 	}
 	if err := graph.AddAttr("G", "ranksep", "\"2.0\""); err != nil {
-		return s, fmt.Errorf("could not add Attribute ranksep: %v", err)
+		return s, fmt.Errorf("could not add Attribute ranksep: %w", err)
 	}
 
 	for service, dependencies := range comp.Services {
 		s := sanitize(service)
 
 		if err := graph.AddNode("G", s, nil); err != nil {
-			return s, fmt.Errorf("could not add service %v to graph: %v", service, err)
+			return s, fmt.Errorf("could not add service %v to graph: %w", service, err)
 		}
 
 		for depservice := range dependencies.DependsOn {
@@ -283,12 +283,12 @@ func outputDotGraph(comp Composition) (s string, err error) {
 
 			if !graph.IsNode(d) {
 				if err := graph.AddNode("G", d, nil); err != nil {
-					return s, fmt.Errorf("could not add service %v to graph: %v", service, err)
+					return s, fmt.Errorf("could not add service %v to graph: %w", service, err)
 				}
 			}
 
 			if err := graph.AddEdge(s, d, true, nil); err != nil {
-				return s, fmt.Errorf("could not add edge from %v to %v: %v", service, depservice, err)
+				return s, fmt.Errorf("could not add edge from %v to %v: %w", service, depservice, err)
 			}
 		}
 	}
@@ -299,11 +299,11 @@ func outputDotGraph(comp Composition) (s string, err error) {
 func compositionFromDockerComposeOutput(file string) (comp Composition, err error) {
 	byteValue, err := os.ReadFile(file)
 	if err != nil {
-		return comp, fmt.Errorf("could not read file %v", err)
+		return comp, fmt.Errorf("could not read file %w", err)
 	}
 
 	if err = json.Unmarshal(byteValue, &comp); err != nil {
-		return comp, fmt.Errorf("could not unmarshal %v", err)
+		return comp, fmt.Errorf("could not unmarshal %w", err)
 	}
 	return comp, nil
 }

--- a/composition.go
+++ b/composition.go
@@ -78,12 +78,9 @@ func (comp *Composition) PrepareForOwnDb() {
 // it takes a comma separated list of service names.
 // These dependencies should be ignored which can be handy when you have external managed ones.
 func (comp *Composition) VerifyDependencies(verifyIgnore string) (err error) {
-	var services, ignored []string
+	ignored := trimSpaces(strings.Split(verifyIgnore, ","))
 
-	for _, n := range strings.Split(verifyIgnore, ",") {
-		ignored = append(ignored, strings.TrimSpace(n))
-	}
-
+	services := make([]string, 0, len(comp.Services))
 	for serviceName := range comp.Services {
 		services = append(services, serviceName)
 	}
@@ -166,13 +163,18 @@ func (comp Composition) Deps(s string) (services []string) {
 	return services
 }
 
+func trimSpaces(sl []string) []string {
+	result := make([]string, len(sl))
+	for i, s := range sl {
+		result[i] = strings.TrimSpace(s)
+	}
+	return result
+}
+
 // error if removed service is a dependencies of another service which should not be removed
 func removeNotWanted(comp Composition, s string) (todo map[string]bool, err error) {
 	todo = make(map[string]bool)
-	var notwanted []string
-	for _, n := range strings.Split(s, ",") {
-		notwanted = append(notwanted, strings.TrimSpace(n))
-	}
+	notwanted := trimSpaces(strings.Split(s, ","))
 
 	for serviceName := range comp.Services {
 		if stringsliceContain(notwanted, serviceName) {

--- a/composition.go
+++ b/composition.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/awalterschulze/gographviz"
+
 	"github.com/simplesurance/dependencies-tool/graphs"
 )
 
@@ -250,7 +251,7 @@ func sortableGraph(comp Composition) (graph *graphs.Graph, err error) {
 
 		for depservice := range dependencies.DependsOn {
 			d := sanitize(depservice)
-			graph.AddEdge(s, d, 0)
+			graph.AddEdge(s, d)
 		}
 	}
 

--- a/composition_test.go
+++ b/composition_test.go
@@ -192,7 +192,7 @@ func TestGetComposition(t *testing.T) {
 
 func TestRemoveNotWanted(t *testing.T) {
 	comp, _ := compositionFromDockerComposeOutput("test/working-compose.json")
-	var list []string
+	var list []string //nolint:prealloc
 
 	mapList, _ := removeNotWanted(comp, "first-service,third")
 	for k := range mapList {

--- a/graphs/graph.go
+++ b/graphs/graph.go
@@ -48,7 +48,7 @@ func (g *Graph) AddVertex(v string) {
 
 // AddEdge adds an edge to the graph. The edge connects
 // vertex v1 and vertex v2.
-func (g *Graph) AddEdge(v1, v2 string, c float64) {
+func (g *Graph) AddEdge(v1, v2 string) {
 	g.AddVertex(v1)
 	g.AddVertex(v2)
 

--- a/sisu.go
+++ b/sisu.go
@@ -29,7 +29,7 @@ func (d BaurConf) FindDepTomls(dir string) (tomls []string, err error) {
 	for _, searchDir := range d.Discover.AppDirs {
 		depsCfgs, err := findFilesInSubDir(dir+"/"+searchDir, ".deps*.toml", d.Discover.SearchDepth)
 		if err != nil {
-			return nil, fmt.Errorf("finding dependencies configs failed %v", err)
+			return nil, fmt.Errorf("finding dependencies configs failed %w", err)
 		}
 
 		tomls = append(tomls, depsCfgs...)
@@ -41,7 +41,7 @@ func (d BaurConf) FindDepTomls(dir string) (tomls []string, err error) {
 func loadBaurToml(dir string) (d BaurConf, err error) {
 
 	if _, err := toml.DecodeFile(dir, &d); err != nil {
-		return d, fmt.Errorf("could not load '%s %v", dir, err)
+		return d, fmt.Errorf("could not load '%s %w", dir, err)
 	}
 	return d, nil
 }
@@ -133,13 +133,13 @@ func compositionFromSisuDir(directory string) (comp Composition, err error) {
 
 	tomls, err := applicationTomls(directory)
 	if err != nil {
-		return comp, fmt.Errorf("could not get app tomls, %v", err)
+		return comp, fmt.Errorf("could not get app tomls, %w", err)
 	}
 
 	for _, tomlfile := range tomls {
 		var t tomlService
 		if _, err := toml.DecodeFile(tomlfile, &t); err != nil {
-			return comp, fmt.Errorf("could not toml decode %v, %v", tomlfile, err)
+			return comp, fmt.Errorf("could not toml decode %v, %w", tomlfile, err)
 		}
 		service := NewService()
 		if len(t.TalksTo) > 0 {
@@ -184,13 +184,13 @@ func compositionFromAppdirFile(file string) (comp Composition, err error) {
 
 	tomls, err := appTomlsFromAppDirFile(file)
 	if err != nil {
-		return comp, fmt.Errorf("could not get app tomls, %v", err)
+		return comp, fmt.Errorf("could not get app tomls, %w", err)
 	}
 
 	for _, tomlfile := range tomls {
 		var t tomlService
 		if _, err := toml.DecodeFile(tomlfile, &t); err != nil {
-			return comp, fmt.Errorf("could not toml decode %v, %v", tomlfile, err)
+			return comp, fmt.Errorf("could not toml decode %v, %w", tomlfile, err)
 		}
 		service := NewService()
 		if len(t.TalksTo) > 0 {

--- a/sisu.go
+++ b/sisu.go
@@ -81,7 +81,7 @@ func realDepsToml(dir, region string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("could not find one of the folowing dependency files in %s: %s",
+	return "", fmt.Errorf("could not find one of the following dependency files in %s: %s",
 		dir, strings.Join(filelist, ", "))
 }
 

--- a/sisu.go
+++ b/sisu.go
@@ -46,7 +46,7 @@ func loadBaurToml(dir string) (d BaurConf, err error) {
 	return d, nil
 }
 
-func depsFileSearchList(env, region string) []string {
+func depsFileSearchList(region string) []string {
 	var fileSearchList []string
 
 	if region != "" && environment != "" {
@@ -68,8 +68,8 @@ func depsFileSearchList(env, region string) []string {
 
 // realDepsToml returns found override deps.toml based on
 // given environment and / or region
-func realDepsToml(dir, env, region string) (string, error) {
-	filelist := depsFileSearchList(env, region)
+func realDepsToml(dir, region string) (string, error) {
+	filelist := depsFileSearchList(region)
 
 	for _, f := range filelist {
 		file := filepath.Join(dir, f)
@@ -102,7 +102,7 @@ func findFilesInSubDir(searchDir, filename string, maxdepth int) ([]string, erro
 
 		for _, m := range matches {
 			dir := filepath.Dir(m)
-			depsToml, err := realDepsToml(dir, environment, region)
+			depsToml, err := realDepsToml(dir, region)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
```
prealloc slices

fix the following golangci-lint warnings:
        composition.go:81:2: Consider pre-allocating `ignored` (prealloc)
                var services, ignored []string
                ^
        composition.go:172:2: Consider pre-allocating `notwanted` (prealloc)
                var notwanted []string
                ^
        composition_test.go:195:2: Consider pre-allocating `list` (prealloc)
                var list []string

-------------------------------------------------------------------------------
wrap errors instead of including their message in another error

This fixes multiple golangci-lint errors like:
  non-wrapping format verb for fmt.Errorf. Use `%w` to format errors
  (errorlint)

-------------------------------------------------------------------------------
sisu: fix: 'folowing' misspelling

This fixes the golangci-lint warning:
  sisu.go:84:51: `folowing` is a misspelling of `following` (misspell)
  return "", fmt.Errorf("could not find one of the folowing dependency
  files in %s: %s",

-------------------------------------------------------------------------------
sisu: remove unused function parameters

Fix the following golangci-lint warning:
  sisu.go:49:25: unused-parameter: parameter 'env' seems to be unused,
  consider removing or renaming it as _ (revive)
  func depsFileSearchList(env, region string) []string {

  sisu.go:71:24: unused-parameter: parameter 'env' seems to be unused,
  consider removing or renaming it as _ (revive)
  func realDepsToml(dir, env, region string) (string, error) {

-------------------------------------------------------------------------------
graphs: remove unused function parameter

Fix the following golangci-lint warning:
  graphs/graph.go:51:40: unused-parameter: parameter 'c' seems to be
  unused, consider removing or renaming it as _ (revive)
  func (g *Graph) AddEdge(v1, v2 string, c float64) {

-------------------------------------------------------------------------------
ci: add custom golangci-lint config

add a custom golangci-lint config that enables more linters + sets the
local import path prefix for the goimport formatter

-------------------------------------------------------------------------------
```