### PR TITLE
deployorder: do not quote printed application names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dependencies-tool
+*.orig

--- a/README.md
+++ b/README.md
@@ -1,45 +1,52 @@
-# Dependencies
+# dependencies-tool
+
 ## What
 
-dependencies is a small command client tool to get (recursive) dependencies out of our applications.
+dependencies-tool is a command client tool that generates ordered lists from
+dependency trees.
 
 ## How
 
-This tool is able to collect dependency information in 1 way.
+This tool is able to generate dependency trees from the following inputs:
 
-  1. provide sisu directory
+1. A directory tree containing `.deps*.toml` files in child directories.
+   It reads the `Discover.application_dirs` list of the `.baur.toml` in the root
+   directory. In all sub-directories of the `Discover.application_dirs`
+   directories, it searches looks for files matching the following names, the
+   first found in the following preference order is read:
 
-  If you provide the **-sisu** parameter, it will read the **.baur.toml** file to get the directories where to find the applications.
-  Inside of the application directory it will look for a **.deps.toml** file where the dependencies of tha application is defined.
+   - `.deps-<ENV>-<REGION>.toml`,
+   - `.deps-<REGION>.toml`,
+   - `.deps-<ENVIRONMENT>.toml`,
+   - `.deps.toml`
 
-### deps.toml
+   The values for `<ENV>` and `<REGION`> can be specified as command line
+   arguments.
 
-Structure:
-```
+2. A marshalled dependency tree that was created by `dependency-tool export`.
+
+### `deps.toml` File Format
+
+Format:
+
+```toml
 name = "a-service"
-talks_to = [ "consul","postgres" ]
+talks_to = ["consul", "postgres"]
 ```
 
-### What
+## Examples
 
-  1. Give me an ordered list of services I need to deploy in order to do integration tests
-     1.1  This list can be a comma separated list of services like this: **...  -service claim-service,pdfrender-service**
+1. Give me an ordered list of application names to deploy:
 
+    ```sh
+    dependencies-tool deploy-order --apps actionrequest-service ~/git/sisu eu staging
+    ```
 
-```
-% ./dependencies deploy-order ~/sandbox/git/work/sisu stg eu -service actionrequest-service
-deployment order for actionrequest-service service(s)
-"consul"
-"rabbitmq"
-...
-...
-"actionrequest-service"
-```
+2. Generate a [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language))
+   graph, that can be visualized with [Graphviz](https://graphviz.org)
 
+    ```sh
+    dependencies-tool deploy-order --format dot --apps actionrequest-service ~/git/sisu eu staging
+    ```
 
-  2. Generate a visualization:
-
-```
-./dependencies deploy-order --format dot ~/sandbox/git/work/sisu stg eu -service certificate-service > output.dot
-dot -Tsvg -o output.svg output.dot
-```
+---

--- a/README.md
+++ b/README.md
@@ -43,24 +43,3 @@ deployment order for actionrequest-service service(s)
 ./dependencies deploy-order --format dot ~/sandbox/git/work/sisu stg eu -service certificate-service > output.dot
 dot -Tsvg -o output.svg output.dot
 ```
-
-## Version Management
-
-The sisu-deploy Jenkins Job uses the dependency tool during deployment.
-The Jenkins jobs needs to use the dependency-tool version that is compatible
-with the current branch.
-Incompatibles can be introduced by e.g.:
-- changes in the baur configuration file and builds of the dependency-tool that
-- use newer baur packages,
-- syntax changes in `.deps.toml`,
-- changes in the commandline parameter of the depdencies-tool
-
-Compatibility between the sisu-deploy job, the branch that is deployed and the
-tool is done by:
-
-- Adding a version number to the artifact filename that is uploaded to S3
-  in its `.app.toml` file.
-- Ensuring in the `sisu-deploy.Jenkinsfile` that the compatible
-  dependencies-tool version is used,
-- Executing the `sisu-deploy.Jenkinsfile` from the branch that is deployed in the
-  Jenkins job

--- a/internal/cmd/deployorder.go
+++ b/internal/cmd/deployorder.go
@@ -23,9 +23,10 @@ discovered by searching in all child directories of SRC-PATH.
 Files that match the following names are discovered, only the first found per
 directory is parsed, the preference order is:
 
-  1. .deps-<ENVIRONMENT>-<REGION>.toml
-  2. .deps-<ENVIRONMENT>.toml
-  3. .deps.toml
+  1. .deps-<ENV>-<REGION>.toml
+  2. .deps-<REGION>.toml
+  3. .deps-<ENVIRONMENT>.toml
+  4. .deps.toml
 `)
 
 var deployOrderLongHelp = deployOrderShortHelp + "\n\n" + strings.TrimSpace(`

--- a/internal/cmd/deployorder.go
+++ b/internal/cmd/deployorder.go
@@ -47,7 +47,7 @@ type deployOrder struct {
 	apps   []string
 
 	src    string
-	eEnv   string
+	Env    string
 	region string
 
 	srcType fs.PathType
@@ -93,6 +93,9 @@ func newDeployOrder() *deployOrder {
 				return fmt.Errorf("expecting 3 arguments, got: %d", len(args))
 			}
 
+			cmd.Env = args[1]
+			cmd.region = args[2]
+
 		case fs.PathTypeFile:
 			if len(args) != 1 {
 				return fmt.Errorf("expecting 1 arguments, got: %d", len(args))
@@ -103,8 +106,6 @@ func newDeployOrder() *deployOrder {
 		}
 
 		cmd.src = args[0]
-		cmd.eEnv = args[1]
-		cmd.region = args[2]
 		cmd.srcType = pType
 
 		return validateAppsParam(cmd.apps)
@@ -114,7 +115,7 @@ func newDeployOrder() *deployOrder {
 	return &cmd
 }
 
-func (c *deployOrder) run(*cobra.Command, []string) error {
+func (c *deployOrder) run(cc *cobra.Command, _ []string) error {
 	var depsfrom deps.Composition
 
 	composition, err := c.loadComposition()
@@ -140,7 +141,7 @@ func (c *deployOrder) run(*cobra.Command, []string) error {
 		}
 
 		for _, i := range secondsorted {
-			fmt.Println(i)
+			cc.Println(i)
 		}
 	case "dot":
 		fmt.Printf("###########\n# dot of %s\n##########\n", strings.Join(c.apps, ", "))
@@ -149,7 +150,7 @@ func (c *deployOrder) run(*cobra.Command, []string) error {
 			return err
 		}
 
-		fmt.Println(depsgraph)
+		cc.Println(depsgraph)
 	}
 
 	return nil
@@ -167,7 +168,7 @@ func validateAppsParam(apps []string) error {
 func (c *deployOrder) loadComposition() (*deps.Composition, error) {
 	switch c.srcType {
 	case fs.PathTypeDir:
-		return deps.CompositionFromSisuDir(c.src, c.eEnv, c.region)
+		return deps.CompositionFromSisuDir(c.src, c.Env, c.region)
 
 	case fs.PathTypeFile:
 		return deps.CompositionFromJSON(c.src)

--- a/internal/cmd/deployorder.go
+++ b/internal/cmd/deployorder.go
@@ -14,12 +14,8 @@ import (
 const deployOrderShortHelp = "Generate a deployment order."
 
 var descrDependencyFileNames = strings.TrimSpace(`
-The command can use as input either a marshalled dependency-tree file 
-or read and parse .deps*.toml file that are found in a parent directory to
-generate a dependency-tree.
-
-If the path to a directory is specified, dependency definitions files are
-discovered by searching in all child directories of SRC-PATH.
+Dependency definitions files are discovered by searching in all child
+directories of ROOT-DIR.
 Files that match the following names are discovered, only the first found per
 directory is parsed, the preference order is:
 
@@ -29,14 +25,22 @@ directory is parsed, the preference order is:
   4. .deps.toml
 `)
 
-var deployOrderLongHelp = deployOrderShortHelp + "\n\n" + strings.TrimSpace(`
-Positional Arguments:
-  ROOT-DIR	- Path to root directory for the dependency file discovery.
-  DEP-TREE-FILE	- Path to an exported JSON dependency tree.
-  ENVIRONMENT   - Value that is used as the ENVIRONMENT placeholder of the 
+const descRootDirArg = `  ROOT-DIR	- Path to root directory for the dependency file discovery.`
+
+const descrEnvRegionArgs = `  ENVIRONMENT   - Value that is used as the ENVIRONMENT placeholder of the 
                   searched dependency file names.
   REGION        - Value that is used as the REGION placeholder of the searched
 		  dependency file names.
+`
+
+var deployOrderLongHelp = deployOrderShortHelp + "\n\n" + strings.TrimSpace(`
+Positional Arguments:
+`+descRootDirArg+`
+  DEP-TREE-FILE	- Path to an exported JSON dependency tree.
+`+descrEnvRegionArgs+`
+The command can use as input either a marshalled dependency-tree file (DEP-TREE-FILE)
+or read and parse .deps*.toml file that are found in child directories of
+ROOT-DIR to generate a dependency-tree.
 
 `+descrDependencyFileNames)
 
@@ -72,7 +76,7 @@ func newDeployOrder() *deployOrder {
 	)
 	cmd.Flags().StringSliceVar(
 		&cmd.apps, "apps", nil,
-		"comma-separated list of apps to generate the deploy order for, "+
+		"comma-separated list of apps to generate the deploy order for,\n"+
 			"if unset, the deploy-order is generated for all found apps.",
 	)
 

--- a/internal/cmd/deployorder.go
+++ b/internal/cmd/deployorder.go
@@ -148,7 +148,7 @@ func (c *deployOrder) run(cc *cobra.Command, _ []string) error {
 			cc.Println(i)
 		}
 	case "dot":
-		fmt.Printf("###########\n# dot of %s\n##########\n", strings.Join(c.apps, ", "))
+		cc.Printf("###########\n# dot of %s\n##########\n", strings.Join(c.apps, ", "))
 		depsgraph, err := deps.OutputDotGraph(depsfrom)
 		if err != nil {
 			return err

--- a/internal/cmd/deployorder_test.go
+++ b/internal/cmd/deployorder_test.go
@@ -35,10 +35,10 @@ func TestExportImport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expectedOut = `"stg-eu-service"
-"postgres"
-"consul"
-"a-service"
+	const expectedOut = `stg-eu-service
+postgres
+consul
+a-service
 `
 	outStr := stdoutBuf.String()
 	if outStr != expectedOut {

--- a/internal/cmd/deployorder_test.go
+++ b/internal/cmd/deployorder_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+)
+
+func TestExportImport(t *testing.T) {
+	tmpdir := t.TempDir()
+	destFile := filepath.Join(tmpdir, "tree.json")
+
+	exportcmd := newExportCmd()
+	exportcmd.root = filepath.Join("..", "deps", "testdata")
+	exportcmd.region = "eu"
+	exportcmd.env = "stg"
+	exportcmd.destFile = destFile
+
+	err := exportcmd.run(exportcmd.Command, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deployOrderCmd := newDeployOrder()
+
+	err = deployOrderCmd.PreRunE(nil, []string{destFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutBuf := bytes.Buffer{}
+	deployOrderCmd.Command.SetOut(&stdoutBuf)
+
+	err = deployOrderCmd.run(deployOrderCmd.Command, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expectedOut = `"stg-eu-service"
+"postgres"
+"consul"
+"a-service"
+`
+	outStr := stdoutBuf.String()
+	if outStr != expectedOut {
+		t.Errorf("got deployorder:\n---\n%s---\n\nexpected:\n---\n%s\n---", outStr, expectedOut)
+	}
+}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -12,26 +12,26 @@ import (
 type exportCmd struct {
 	*cobra.Command
 
-	Root     string
-	Env      string
-	Region   string
-	DestFile string
+	root     string
+	env      string
+	region   string
+	destFile string
 }
 
 func newExportCmd() *exportCmd {
 	cmd := exportCmd{
 		Command: &cobra.Command{
-			Use:   "export ROOT-PATH ENVIRONMENT REGION DEST-FILE",
+			Use:   "export ROOT-DIR ENVIRONMENT REGION DEST-FILE",
 			Short: "Write the parsed dependency tree to a file.",
 			Args:  cobra.ExactArgs(4),
 		},
 	}
 
 	cmd.PreRunE = func(_ *cobra.Command, args []string) error {
-		cmd.Root = args[0]
-		cmd.Env = args[1]
-		cmd.Region = args[2]
-		cmd.DestFile = args[3]
+		cmd.root = args[0]
+		cmd.env = args[1]
+		cmd.region = args[2]
+		cmd.destFile = args[3]
 
 		return nil
 	}
@@ -41,17 +41,17 @@ func newExportCmd() *exportCmd {
 }
 
 func (c *exportCmd) run(*cobra.Command, []string) error {
-	absPath, err := filepath.Abs(c.DestFile)
+	absPath, err := filepath.Abs(c.destFile)
 	if err != nil {
 		return err
 	}
 
-	cmp, err := deps.CompositionFromSisuDir(c.Root, c.Env, c.Region)
+	cmp, err := deps.CompositionFromSisuDir(c.root, c.env, c.region)
 	if err != nil {
 		return err
 	}
 
-	err = cmp.ToJSONFile(c.DestFile)
+	err = cmp.ToJSONFile(c.destFile)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/simplesurance/dependencies-tool/internal/deps"
+)
+
+type exportCmd struct {
+	*cobra.Command
+
+	Root     string
+	Env      string
+	Region   string
+	DestFile string
+}
+
+func newExportCmd() *exportCmd {
+	cmd := exportCmd{
+		Command: &cobra.Command{
+			Use:   "export ROOT-PATH ENVIRONMENT REGION DEST-FILE",
+			Short: "Write the parsed dependency tree to a file.",
+			Args:  cobra.ExactArgs(4),
+		},
+	}
+
+	cmd.PreRunE = func(_ *cobra.Command, args []string) error {
+		cmd.Root = args[0]
+		cmd.Env = args[1]
+		cmd.Region = args[2]
+		cmd.DestFile = args[3]
+
+		return nil
+	}
+	cmd.RunE = cmd.run
+
+	return &cmd
+}
+
+func (c *exportCmd) run(*cobra.Command, []string) error {
+	absPath, err := filepath.Abs(c.DestFile)
+	if err != nil {
+		return err
+	}
+
+	cmp, err := deps.CompositionFromSisuDir(c.Root, c.Env, c.Region)
+	if err != nil {
+		return err
+	}
+
+	err = cmp.ToJSONFile(c.DestFile)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("written dependency tree to %s\n", absPath)
+
+	return nil
+}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -8,6 +8,14 @@ import (
 	"github.com/simplesurance/dependencies-tool/internal/deps"
 )
 
+const exportCmdShortHelp = "Generate a dependency tree and export it to a file."
+
+var exportCmdLongHelp = exportCmdShortHelp + "\n\n" +
+	`Positional Arguments:
+` + descRootDirArg + `
+` + descrEnvRegionArgs + `
+` + descrDependencyFileNames
+
 type exportCmd struct {
 	*cobra.Command
 
@@ -21,7 +29,8 @@ func newExportCmd() *exportCmd {
 	cmd := exportCmd{
 		Command: &cobra.Command{
 			Use:   "export ROOT-DIR ENVIRONMENT REGION DEST-FILE",
-			Short: "Write the parsed dependency tree to a file.",
+			Short: exportCmdShortHelp,
+			Long:  exportCmdLongHelp,
 			Args:  cobra.ExactArgs(4),
 		},
 	}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ func newExportCmd() *exportCmd {
 	return &cmd
 }
 
-func (c *exportCmd) run(*cobra.Command, []string) error {
+func (c *exportCmd) run(cc *cobra.Command, _ []string) error {
 	absPath, err := filepath.Abs(c.destFile)
 	if err != nil {
 		return err
@@ -56,7 +55,7 @@ func (c *exportCmd) run(*cobra.Command, []string) error {
 		return err
 	}
 
-	fmt.Printf("written dependency tree to %s\n", absPath)
+	cc.Printf("written dependency tree to %s\n", absPath)
 
 	return nil
 }

--- a/internal/cmd/fs/fs.go
+++ b/internal/cmd/fs/fs.go
@@ -1,0 +1,31 @@
+package fs
+
+import (
+	"fmt"
+	"os"
+)
+
+type PathType int
+
+const (
+	PathTypeUndefined PathType = iota
+	PathTypeDir
+	PathTypeFile
+)
+
+func FileOrDir(path string) (PathType, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return -1, err
+	}
+
+	if info.IsDir() {
+		return PathTypeDir, nil
+	}
+
+	if info.Mode().IsRegular() {
+		return PathTypeFile, nil
+	}
+
+	return -1, fmt.Errorf("path isn't a directory nor a regular file")
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+)
 
 func newRoot() *cobra.Command {
 	const shortDesc = "Visualize Dependencies and generate deployment orders"
@@ -13,6 +15,7 @@ func newRoot() *cobra.Command {
 
 	root.AddCommand(newDeployOrder().Command)
 	root.AddCommand(newVerify().Command)
+	root.AddCommand(newExportCmd().Command)
 
 	return root
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -21,5 +23,6 @@ func newRoot() *cobra.Command {
 
 func Execute() {
 	root := newRoot()
+	root.SetOut(os.Stdout)
 	_ = root.Execute()
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,7 +9,6 @@ func newRoot() *cobra.Command {
 
 	root := &cobra.Command{
 		Short:        shortDesc,
-		Long:         descrDependencyFileNames,
 		SilenceUsage: true,
 	}
 

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -10,9 +10,9 @@ import (
 
 type verify struct {
 	*cobra.Command
-	Path   string
-	Env    string
-	Region string
+	path   string
+	env    string
+	region string
 }
 
 func newVerify() *verify {
@@ -27,16 +27,16 @@ func newVerify() *verify {
 	cmd.RunE = cmd.run
 
 	cmd.PreRun = func(_ *cobra.Command, args []string) {
-		cmd.Path = args[0]
-		cmd.Env = args[1]
-		cmd.Region = args[2]
+		cmd.path = args[0]
+		cmd.env = args[1]
+		cmd.region = args[2]
 	}
 
 	return &cmd
 }
 
 func (c *verify) run(*cobra.Command, []string) error {
-	composition, err := deps.CompositionFromSisuDir(c.Path, c.Env, c.Region)
+	composition, err := deps.CompositionFromSisuDir(c.path, c.env, c.region)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/dependencies-tool/internal/deps"
@@ -35,7 +33,7 @@ func newVerify() *verify {
 	return &cmd
 }
 
-func (c *verify) run(*cobra.Command, []string) error {
+func (c *verify) run(cc *cobra.Command, _ []string) error {
 	composition, err := deps.CompositionFromSisuDir(c.path, c.env, c.region)
 	if err != nil {
 		return err
@@ -45,7 +43,7 @@ func (c *verify) run(*cobra.Command, []string) error {
 		return err
 	}
 
-	fmt.Println("verification successful")
+	cc.Println("verification successful")
 
 	return nil
 }

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -36,8 +36,6 @@ func newVerify() *verify {
 }
 
 func (c *verify) run(*cobra.Command, []string) error {
-	var composition deps.Composition
-
 	composition, err := deps.CompositionFromSisuDir(c.Path, c.Env, c.Region)
 	if err != nil {
 		return err

--- a/internal/cmd/verify.go
+++ b/internal/cmd/verify.go
@@ -1,10 +1,20 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/simplesurance/dependencies-tool/internal/deps"
 )
+
+const verifyShortHelp = "Verify dependency files"
+
+var verifyLongHelp = verifyShortHelp + "\n\n" + strings.TrimSpace(`
+Positional Arguments:
+`+descRootDirArg+`
+`+descrEnvRegionArgs+`
+`+descrDependencyFileNames)
 
 type verify struct {
 	*cobra.Command
@@ -17,7 +27,8 @@ func newVerify() *verify {
 	cmd := verify{
 		Command: &cobra.Command{
 			Use:   "verify PATH ENVIRONMENT REGION",
-			Short: "Verify dependency files",
+			Short: verifyShortHelp,
+			Long:  verifyLongHelp,
 			Args:  cobra.ExactArgs(3),
 		},
 	}

--- a/internal/deps/composition.go
+++ b/internal/deps/composition.go
@@ -1,7 +1,9 @@
 package deps
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -199,6 +201,21 @@ func (comp Composition) RecursiveDepsOf(s string) (newcomp *Composition, err err
 	}
 
 	return newcomp, nil
+}
+
+func (comp *Composition) ToJSONFile(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+
+	err = json.NewEncoder(f).Encode(comp)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	return f.Close()
 }
 
 func sortableGraph(comp Composition) (graph *graphs.Graph, err error) {

--- a/internal/deps/composition.go
+++ b/internal/deps/composition.go
@@ -114,10 +114,6 @@ func (comp *Composition) AddService(name string, service Service) {
 	}
 }
 
-func sanitize(in string) string {
-	return "\"" + in + "\""
-}
-
 // DeploymentOrder ... deploy from order[0] to order[len(order) -1] :)
 func (comp Composition) DeploymentOrder() (order []string, err error) {
 
@@ -126,7 +122,7 @@ func (comp Composition) DeploymentOrder() (order []string, err error) {
 
 	for serviceName := range comp.Services {
 		if len(comp.Services[serviceName].DependsOn) == 0 {
-			nodeps = append(nodeps, sanitize(serviceName))
+			nodeps = append(nodeps, serviceName)
 		}
 	}
 
@@ -167,7 +163,7 @@ func (comp Composition) DeploymentOrder() (order []string, err error) {
 func (comp Composition) Deps(s string) (services []string) {
 	if _, ok := comp.Services[s]; ok {
 		for depservice := range comp.Services[s].DependsOn {
-			services = append(services, sanitize(depservice))
+			services = append(services, depservice)
 		}
 	}
 	return services
@@ -237,11 +233,11 @@ func sortableGraph(comp Composition) (graph *graphs.Graph, err error) {
 	graph = graphs.NewDigraph()
 
 	for service, dependencies := range comp.Services {
-		s := sanitize(service)
+		s := service
 		graph.AddVertex(s)
 
 		for depservice := range dependencies.DependsOn {
-			d := sanitize(depservice)
+			d := depservice
 			graph.AddEdge(s, d)
 		}
 	}
@@ -263,14 +259,14 @@ func OutputDotGraph(comp Composition) (s string, err error) {
 	}
 
 	for service, dependencies := range comp.Services {
-		s := sanitize(service)
+		s := service
 
 		if err := graph.AddNode("G", s, nil); err != nil {
 			return s, fmt.Errorf("could not add service %v to graph: %w", service, err)
 		}
 
 		for depservice := range dependencies.DependsOn {
-			d := sanitize(depservice)
+			d := depservice
 
 			if !graph.IsNode(d) {
 				if err := graph.AddNode("G", d, nil); err != nil {

--- a/internal/deps/composition.go
+++ b/internal/deps/composition.go
@@ -45,18 +45,17 @@ func NewComposition() *Composition {
 	return &Composition{Services: svs}
 }
 
-func CompositionFromSisuDir(directory, env, region string) (comp Composition, err error) {
-	comp = *NewComposition()
-
+func CompositionFromSisuDir(directory, env, region string) (*Composition, error) {
 	tomls, err := applicationTomls(directory, env, region)
 	if err != nil {
-		return comp, fmt.Errorf("could not get app tomls, %w", err)
+		return nil, fmt.Errorf("could not get app tomls, %w", err)
 	}
 
+	comp := NewComposition()
 	for _, tomlfile := range tomls {
 		var t tomlService
 		if _, err := toml.DecodeFile(tomlfile, &t); err != nil {
-			return comp, fmt.Errorf("could not toml decode %v, %w", tomlfile, err)
+			return nil, fmt.Errorf("could not toml decode %v, %w", tomlfile, err)
 		}
 		service := NewService()
 		if len(t.TalksTo) > 0 {
@@ -68,6 +67,22 @@ func CompositionFromSisuDir(directory, env, region string) (comp Composition, er
 	}
 
 	return comp, nil
+}
+
+func CompositionFromJSON(filePath string) (*Composition, error) {
+	var result Composition
+
+	fd, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(fd).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }
 
 // VerifyDependencies checks if all given dependencies are valid

--- a/internal/deps/composition_test.go
+++ b/internal/deps/composition_test.go
@@ -38,13 +38,13 @@ func TestVerifyDependencies(t *testing.T) {
 	}
 }
 
-// //
 func TestOutputDotGraph(t *testing.T) {
 	comp := makeTestComp()
 	dot, _ := OutputDotGraph(*comp)
 
-	if !strings.Contains(dot, "\"a\"->\"c\"") {
-		t.Errorf("expected dot to contain '\"a\"->\"c\"' got %v", dot)
+	const expected = "a->c"
+	if !strings.Contains(dot, expected) {
+		t.Errorf("expected dot to contain %q got %q", expected, dot)
 	}
 	_, _ = OutputDotGraph(*comp)
 }
@@ -61,7 +61,7 @@ func TestDeps(t *testing.T) {
 	comp := makeTestComp()
 
 	got := comp.Deps("a")
-	if !Equal(got, []string{"\"c\""}) {
+	if !Equal(got, []string{"c"}) {
 		t.Errorf("expected dep of service a to be %v, got %v", "[\"c\"]", got)
 	}
 }
@@ -69,7 +69,7 @@ func TestDeps(t *testing.T) {
 func TestRecursiveDepsOf(t *testing.T) {
 
 	comp := makeTestComp()
-	exp := []string{"\"c\"", "\"a\""}
+	exp := []string{"c", "a"}
 
 	got, _ := comp.RecursiveDepsOf("a")
 	order, _ := got.DeploymentOrder()
@@ -102,7 +102,7 @@ func TestRecursiveDepsOfWithListOfServicesAndBlank(t *testing.T) {
 
 func TestDeployOrder(t *testing.T) {
 	comp := makeTestComp()
-	exp := []string{"\"c\"", "\"a\"", "\"b\""}
+	exp := []string{"c", "a", "b"}
 	got, _ := comp.DeploymentOrder()
 
 	if !Equal(exp, got) {
@@ -112,8 +112,8 @@ func TestDeployOrder(t *testing.T) {
 
 func TestSanitize(t *testing.T) {
 	s := "mystring"
-	got := sanitize(s)
-	exp := "\"mystring\""
+	got := s
+	exp := "mystring"
 
 	if got != exp {
 		t.Errorf("expected to be result %v , got %v", exp, got)

--- a/internal/deps/sisu_test.go
+++ b/internal/deps/sisu_test.go
@@ -22,13 +22,13 @@ func TestCompositionFromSisuDirenv2(t *testing.T) {
 		reg string
 		exp string
 	}{
-		{"stg", "", "\"stg-service\""},
-		{"", "eu", "\"eu-service\""},
-		{"stg", "eu", "\"stg-eu-service\""},
-		{"", "", "\"default-service\""},
-		{"noenv", "", "\"default-service\""},
-		{"", "noreg", "\"default-service\""},
-		{"noenv", "noreg", "\"default-service\""},
+		{"stg", "", "stg-service"},
+		{"", "eu", "eu-service"},
+		{"stg", "eu", "stg-eu-service"},
+		{"", "", "default-service"},
+		{"noenv", "", "default-service"},
+		{"", "noreg", "default-service"},
+		{"noenv", "noreg", "default-service"},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
Remove surrounding the printed application names in quotes. This will allow to remove in other internal scripts to remove the code that removes the quotes again before we can use the output.

## This must be merged after https://github.com/simplesurance/dependencies-tool/pull/11.