### PR TITLE
configure goreleaser to build and publish artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dependencies-tool
 *.orig
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+version: 1
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - "-X github.com/simplesurance/dependencies-tool/internal/cmd.version={{ .Version }}"
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    wrap_in_directory: false
+    files:
+      # Do not include README.md and LICENCE file in archive
+      # (https://goreleaser-git-revert-1958-snapshot-auto.goreleaser.vercel.app/customization/archive/#packaging-only-the-binaries):
+      - none*
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+signs:
+  - artifacts: checksum
+    args:
+      - "--batch"
+      - "--pinentry-mode"
+      - "loopback"
+      - "--passphrase-fd"
+      - "0"
+      - "--local-user"
+      - "0xC8B381683DBCEDFE"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+    stdin: '{{ .Env.GPG_PASSWORD }}'
+
+release:
+  draft: true
+  prerelease: auto
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,44 @@
+# Release
+
+## How to Create a Release
+
+1. Create a git tag for the new release
+
+   ```sh
+   git tag v<MY-VERSION>
+   ```
+
+   **ADVISE**: Do not push the tag. Instead let it be created by GitHub when
+   removing the draft status. This allows to eventually recreate + delete the
+   draft release without having the tags already on the on the git remote.
+
+2. Import our GPG signing private key:
+   - retrieve the GPG private key password and store it in an environment
+     variable:
+
+       ```sh
+        export GPG_PASSWORD="$(vault read -field=master-priv-key-password secret/gpg-key-platform)"
+       ```
+
+   - import the signing key:
+
+       ```sh
+       vault read -field=subkey-signing-priv-key  secret/gpg-key-platform | \
+           gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSWORD" --import
+       ```
+
+3. Set the `GITHUB_TOKEN` environment variable:
+
+   ```sh
+   export GITHUB_TOKEN=<MY-TOKEN>
+   ```
+
+4. Run goreleaser
+
+    ```sh
+    goreleaser release
+    ```
+
+6. Review the created draft release on
+   [GitHub](https://github.com/simplesurance/dependencies-tool/releases) and
+   publish it.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,12 +6,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// version is set via goreleaser
+var version = "UNDEFINED"
+
 func newRoot() *cobra.Command {
 	const shortDesc = "Visualize Dependencies and generate deployment orders"
 
 	root := &cobra.Command{
 		Short:        shortDesc,
 		SilenceUsage: true,
+		Version:      version,
 	}
 
 	root.AddCommand(newDeployOrder().Command)


### PR DESCRIPTION
Configure goreleleaser to build and publish release artifacts.

The process is documented in docs/RELEASE.md.

We could setup a github action workflow to automate it further: https://goreleaser.com/ci/actions/.

Please also review the created test release: https://github.com/simplesurance/dependencies-tool/releases/tag/untagged-3c59dd6454cbfbd7e902