### PR TITLE
cmd: exit with code 1 on error

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,5 +24,10 @@ func newRoot() *cobra.Command {
 func Execute() {
 	root := newRoot()
 	root.SetOut(os.Stdout)
-	_ = root.Execute()
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(0)
 }


### PR DESCRIPTION
The tool is always existing with code 0, also if an error occurred.

Exit with code 1 if an error happens.