### PR TITLE
deploy-order: fail if non-existing app is specified

### DIFF
--- a/internal/deps/composition.go
+++ b/internal/deps/composition.go
@@ -192,10 +192,9 @@ func (comp Composition) RecursiveDepsOf(s string) (newcomp *Composition, err err
 
 	for len(todo) > 0 {
 		for serviceName := range todo {
-			service, ok := comp.Services[serviceName]
-
+			_, ok := comp.Services[serviceName]
 			if !ok {
-				comp.AddService(serviceName, NewService(service.Deployable))
+				return nil, fmt.Errorf("application %s does not exist", serviceName)
 			}
 
 			newcomp.Services[serviceName] = comp.Services[serviceName]

--- a/internal/deps/composition_test.go
+++ b/internal/deps/composition_test.go
@@ -85,17 +85,6 @@ func TestRecursiveDepsOf(t *testing.T) {
 	}
 }
 
-func TestRecursiveDepsOfWithListOfServices(t *testing.T) {
-	comp := newTestComp()
-
-	got, _ := comp.RecursiveDepsOf("fourth-service,first-service")
-
-	_, ok := got.Services["fifth-service"]
-	if !ok {
-		t.Error("expected to have 'fifth-service' in composition")
-	}
-}
-
 func TestRecursiveDepsOfWithListOfServicesAndBlank(t *testing.T) {
 	comp := newTestComp()
 	got, _ := comp.RecursiveDepsOf("fifth-service, fourth-service")
@@ -214,4 +203,13 @@ func TestDeployOrderWithUndeployables(t *testing.T) {
 	fatalOnErr(t, err)
 	cmpSlice(t, []string{"d"}, order)
 
+}
+
+func TestRecursiveDepsOfFailsIfUnknownAppIsSpecified(t *testing.T) {
+	comp := NewComposition()
+	_, err := comp.RecursiveDepsOf("xyz")
+	expectedErrStr := "application xyz does not exist"
+	if err == nil || err.Error() != expectedErrStr {
+		t.Fatalf("expected err with msg: %q, got: %v", expectedErrStr, err)
+	}
 }


### PR DESCRIPTION
If an application was specified to calculate the deploy-order for that did not exist in the tree, the app was added to the tree as undeployable, eventually included in the deploy order and the command succeed.

Fail instead if the app does not exist in the dependency tree. This will allow to detect during deployment if an app was specified that does not exist in the exported dependency tree