### PR TITLE
fix: (bash) completion script is broken

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,6 +13,7 @@ func newRoot() *cobra.Command {
 	const shortDesc = "Visualize Dependencies and generate deployment orders"
 
 	root := &cobra.Command{
+		Use:          "dependencies-tool COMMAND",
 		Short:        shortDesc,
 		SilenceUsage: true,
 		Version:      version,


### PR DESCRIPTION
The generated completion shell for at least bash is broken, the completion for other shells I haven't tested.

Because the Use string was not set for the root command, an empty string was used in the generated completion script.
This causes the completion script to not execute because among others the command "complete -o default -F __start_" fails because the command name parameter is missing.