### PR TITLE
export: make DEST-FILE argument optional, write to stdout by default

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -29,16 +30,18 @@ func newExportCmd(root *rootCmd) *exportCmd {
 	cmd := exportCmd{
 		rootCmd: root,
 		Command: &cobra.Command{
-			Use:   "export ROOT-DIR DEST-FILE",
+			Use:   "export ROOT-DIR [DEST-FILE]",
 			Short: exportCmdShortHelp,
 			Long:  exportCmdLongHelp,
-			Args:  cobra.ExactArgs(2),
+			Args:  cobra.RangeArgs(1, 2),
 		},
 	}
 
 	cmd.PreRunE = func(_ *cobra.Command, args []string) error {
 		cmd.root = args[0]
-		cmd.destFile = args[1]
+		if len(args) >= 2 {
+			cmd.destFile = args[1]
+		}
 		return nil
 	}
 	cmd.RunE = cmd.run
@@ -47,11 +50,6 @@ func newExportCmd(root *rootCmd) *exportCmd {
 }
 
 func (c *exportCmd) run(cc *cobra.Command, _ []string) error {
-	absPath, err := filepath.Abs(c.destFile)
-	if err != nil {
-		return err
-	}
-
 	cmp, err := deps.CompositionFromDir(c.root, c.rootCmd.cfgName, c.rootCmd.ignoredDirs)
 	if err != nil {
 		return err
@@ -61,12 +59,17 @@ func (c *exportCmd) run(cc *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not find any dependency information in %s", c.root)
 	}
 
-	err = cmp.ToJSONFile(c.destFile)
-	if err != nil {
-		return err
+	if c.destFile == "" {
+		if err := cmp.ToJSON(os.Stdout); err != nil {
+			return err
+		}
+	} else {
+		err = cmp.ToJSONFile(c.destFile)
+		if err != nil {
+			return err
+		}
+		cc.Printf("written dependency tree to %s\n", filepath.Clean(c.destFile))
 	}
-
-	cc.Printf("written dependency tree to %s\n", absPath)
 
 	return nil
 }

--- a/internal/deps/composition.go
+++ b/internal/deps/composition.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -144,13 +145,16 @@ func (c *Composition) ToJSONFile(path string) error {
 		return err
 	}
 
-	err = json.NewEncoder(f).Encode(c)
+	err = c.ToJSON(f)
 	if err != nil {
 		_ = f.Close()
 		return err
 	}
 
 	return f.Close()
+}
+func (c *Composition) ToJSON(w io.Writer) error {
+	return json.NewEncoder(w).Encode(c)
 }
 
 // createGraph returns a DAG of the dependencies for the given distribution.


### PR DESCRIPTION
Change the export command to write the result by default to stdout and make the DEST-FILE parameter optional.

To simplify the code a bit, change "export [DEST-FILE]" also to print the cleaned path instead of the absolute path of DEST-FILE. This is sufficient. The caller knows where the file is he writes the result to.